### PR TITLE
This commit introduces or changes the following items:

### DIFF
--- a/Source/AdobeConnectSDK/AdobeConnectSDK.csproj
+++ b/Source/AdobeConnectSDK/AdobeConnectSDK.csproj
@@ -77,9 +77,9 @@
     <Compile Include="Extensions\PrincipalManagement.cs" />
     <Compile Include="Extensions\Reporting.cs" />
     <Compile Include="Extensions\UserManagement.cs" />
+    <Compile Include="Common\HttpUtilsInternal.cs" />
     <Compile Include="Model\EventInfo.cs" />
     <Compile Include="Common\HttpCommunicationProvider.cs" />
-    <Compile Include="Common\HttpUtilsInternal.cs" />
     <Compile Include="Interfaces\ICommunicationProvider.cs" />
     <Compile Include="Interfaces\ISdkSettings.cs" />
     <Compile Include="Model\MeetingDetail.cs" />
@@ -103,6 +103,7 @@
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Framework.2.0">

--- a/Source/AdobeConnectSDK/AdobeConnectXmlAPI.cs
+++ b/Source/AdobeConnectSDK/AdobeConnectXmlAPI.cs
@@ -17,319 +17,357 @@ using AdobeConnectSDK.Common;
 using AdobeConnectSDK.Interfaces;
 using AdobeConnectSDK.Model;
 
+
 namespace AdobeConnectSDK
 {
-  /// <summary>
-  /// AdobeConnectXmlAPI - .Net wrapper for Adobe Connect Professional web services.
-  /// Version supported: from 6 and up.
-  /// </summary>
-  [System.Web.AspNetHostingPermission(System.Security.Permissions.SecurityAction.Demand, Level = System.Web.AspNetHostingPermissionLevel.Minimal)]
-  public sealed class AdobeConnectXmlAPI
-  {
-    string sessionInfo = string.Empty;
-
-    private readonly ICommunicationProvider communicationProvider;
-
-    private readonly ISdkSettings settings;
-
-      /// <summary>
-      /// Initializes a new instance of the <see cref="AdobeConnectXmlAPI"/> class, using default <see cref="HttpCommunicationProvider"/> and <see cref="SdkSettings"/>.
-      /// </summary>
-      /// <remarks>
-      /// <para>Default constructor expects the following configuration defined:</para>
-      /// <para>&lt;add key="ServiceURL" value="https://acrobat.com/api/xml" /&gt;</para>
-      /// <para>&lt;add key="NetUser" value="[your AC user]" /&gt;</para>
-      /// <para>&lt;add key="NetPassword" value="[your AC password]" /&gt;</para>
-      /// <para>Optional proxy settings:</para>
-      /// <para>&lt;settings&gt;</para>
-      /// <para>&lt;ipv6 enabled="true" /&gt;</para>
-      /// <para>&lt;/settings&gt;</para>
-      /// <para>&lt;defaultProxy enabled="true" useDefaultCredentials="true"&gt;</para>
-      /// <para>    &lt;proxy bypassonlocal="True" proxyaddress="http://..." /&gt;</para>
-      /// <para>&lt;/defaultProxy&gt;</para>
-      /// </remarks>
-      public AdobeConnectXmlAPI()
-          : this(new HttpCommunicationProvider(), new SdkSettings()
-          {
-              ServiceURL = ConfigurationManager.AppSettings["ServiceURL"],
-              NetUser = ConfigurationManager.AppSettings["NetUser"],
-              NetPassword = ConfigurationManager.AppSettings["NetPassword"],
-              NetDomain = ConfigurationManager.AppSettings["NetDomain"],
-              ProxyUrl = ConfigurationManager.AppSettings["ProxyUrl"],
-              UseSessionParam = ConfigurationManager.AppSettings["UseSessionParam"] == null || bool.Parse(ConfigurationManager.AppSettings["UseSessionParam"])
-          }) 
-	  { }
-
     /// <summary>
-    /// Initializes a new instance of the <see cref="AdobeConnectXmlAPI" /> class.
+    /// AdobeConnectXmlAPI - .Net wrapper for Adobe Connect Professional web services.
+    /// Version supported: from 6 and up.
     /// </summary>
-    /// <param name="communicationProvider">The communicaton provider.</param>
-    /// <param name="settings"><see cref="ISdkSettings"/></param>
-    /// <exception cref="System.ArgumentNullException">
-    /// Argument 'communicationProvider' can not be null.
-    /// or
-    /// Argument 'settings' can not be null.
-    /// or
-    /// Configuration parameter 'serviceURL' can not be null.
-    /// </exception>
-    public AdobeConnectXmlAPI(ICommunicationProvider communicationProvider, ISdkSettings settings)
-    {
-      if (communicationProvider == null)
-        throw new ArgumentNullException("Argument 'communicationProvider' can not be null.");
+    [System.Web.AspNetHostingPermission(System.Security.Permissions.SecurityAction.Demand, Level = System.Web.AspNetHostingPermissionLevel.Minimal)]
+    public sealed class AdobeConnectXmlAPI
+    {       
+        string sessionInfo = string.Empty;
 
-      if (settings == null)
-        throw new ArgumentNullException("Argument 'settings' can not be null.");
+        private readonly ICommunicationProvider communicationProvider;
 
-      if (string.IsNullOrEmpty(settings.ServiceURL))
-        throw new ArgumentNullException("Configuration parameter 'serviceURL' can not be null.");
+        private readonly ISdkSettings settings;
 
-      this.communicationProvider = communicationProvider;
-      this.settings = settings;
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AdobeConnectXmlAPI"/> class, using default <see cref="HttpCommunicationProvider"/> and <see cref="SdkSettings"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>Default constructor expects the following configuration defined:</para>
+        /// <para>&lt;add key="ServiceURL" value="https://acrobat.com/api/xml" /&gt;</para>
+        /// <para>&lt;add key="NetUser" value="[your AC user]" /&gt;</para>
+        /// <para>&lt;add key="NetPassword" value="[your AC password]" /&gt;</para>
+        /// <para>Optional proxy settings:</para>
+        /// <para>&lt;settings&gt;</para>
+        /// <para>&lt;ipv6 enabled="true" /&gt;</para>
+        /// <para>&lt;/settings&gt;</para>
+        /// <para>&lt;defaultProxy enabled="true" useDefaultCredentials="true"&gt;</para>
+        /// <para>    &lt;proxy bypassonlocal="True" proxyaddress="http://..." /&gt;</para>
+        /// <para>&lt;/defaultProxy&gt;</para>
+        /// </remarks>
+        public AdobeConnectXmlAPI()
+            : this(new HttpCommunicationProvider(), new SdkSettings()
+            {
+                ServiceURL = ConfigurationManager.AppSettings["ServiceURL"],
+                NetUser = ConfigurationManager.AppSettings["NetUser"],
+                NetPassword = ConfigurationManager.AppSettings["NetPassword"],
+                NetDomain = ConfigurationManager.AppSettings["NetDomain"],
+                ProxyUrl = ConfigurationManager.AppSettings["ProxyUrl"],
+                UseSessionParam = ConfigurationManager.AppSettings["UseSessionParam"] == null || bool.Parse(ConfigurationManager.AppSettings["UseSessionParam"])
+            })
+        {
+        }
 
-      this.settings.ServiceURL = this.settings.ServiceURL.TrimEnd(new char[] { '/', '?' });
-      if (!this.settings.ServiceURL.EndsWith("/api/xml"))
-      {
-        this.settings.ServiceURL = this.settings.ServiceURL.TrimEnd(new char[] { '/' }) + "/api/xml";
-      }
-    }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AdobeConnectXmlAPI"/> class, using default <see cref="HttpCommunicationProvider"/> and <see cref="SdkSettings"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>Default constructor expects the following configuration defined:</para>
+        /// <para>&lt;add key="ServiceURL" value="https://acrobat.com/api/xml" /&gt;</para>
+        /// <para>&lt;add key="NetUser" value="[your AC user]" /&gt;</para>
+        /// <para>&lt;add key="NetPassword" value="[your AC password]" /&gt;</para>
+        /// <para>Optional proxy settings:</para>
+        /// <para>&lt;settings&gt;</para>
+        /// <para>&lt;ipv6 enabled="true" /&gt;</para>
+        /// <para>&lt;/settings&gt;</para>
+        /// <para>&lt;defaultProxy enabled="true" useDefaultCredentials="true"&gt;</para>
+        /// <para>    &lt;proxy bypassonlocal="True" proxyaddress="http://..." /&gt;</para>
+        /// <para>&lt;/defaultProxy&gt;</para>
+        /// </remarks>
+        public AdobeConnectXmlAPI(ICommunicationProvider communicatonProvider)
+            : this(communicatonProvider, new SdkSettings()
+            {
+                ServiceURL = ConfigurationManager.AppSettings["ServiceURL"],
+                NetUser = ConfigurationManager.AppSettings["NetUser"],
+                NetPassword = ConfigurationManager.AppSettings["NetPassword"],
+                NetDomain = ConfigurationManager.AppSettings["NetDomain"],
+                ProxyUrl = ConfigurationManager.AppSettings["ProxyUrl"],
+                UseSessionParam = ConfigurationManager.AppSettings["UseSessionParam"] == null || bool.Parse(ConfigurationManager.AppSettings["UseSessionParam"])
+            })
+        {
+        }
 
-    /// <summary>
-    /// Performs log-in procedure.
-    /// </summary>
-    /// <param name="sInfo">after successful Login, <see cref="LoginStatus"/> contains Session ID to be used for single-sign-on.</param>
-    /// <returns>An <see cref="LoginStatus"/></returns>
-    /// <example>
-    /// url: action=Login&Login=bobs@acme.com&password=football&Session=
-    /// cookie: BREEZESESSION
-    /// </example>
-    public LoginStatus Login()
-    {
-      return this.Login(this.settings.NetUser, this.settings.NetPassword);
-    }
 
-    /// <summary>
-    /// Performs log-in procedure.
-    /// </summary>
-    /// <param name="userName">valid Adobe Connect account Name.</param>
-    /// <param name="userPassword">valid Adobe Connect account password.</param>
-    /// <param name="sInfo">after successful Login, <see cref="LoginStatus"/> contains Session ID to be used for single-sign-on.</param>
-    /// <returns>An <see cref="LoginStatus"/></returns>
-    /// <example>
-    /// url: action=Login&Login=bobs@acme.com&password=football&Session=
-    /// cookie: BREEZESESSION
-    /// </example>
-    public LoginStatus Login(string userName, string userPassword)
-    {
-      ApiStatus s = this.ProcessApiRequest("login", string.Format("login={0}&password={1}", userName, userPassword));
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AdobeConnectXmlAPI" /> class.
+        /// </summary>
+        /// <param name="communicationProvider">The communicaton provider.</param>
+        /// <param name="settings"><see cref="ISdkSettings"/></param>
+        /// <exception cref="System.ArgumentNullException">
+        /// Argument 'communicationProvider' can not be null.
+        /// or
+        /// Argument 'settings' can not be null.
+        /// or
+        /// Configuration parameter 'serviceURL' can not be null.
+        /// </exception>
+        public AdobeConnectXmlAPI(ICommunicationProvider communicationProvider, ISdkSettings settings)
+        {
+            if (settings == null)
+                throw new ArgumentNullException("Argument 'settings' can not be null.");
 
-      var loginStatus = Helpers.WrapBaseStatusInfo<LoginStatus>(s);
+            if (string.IsNullOrEmpty(settings.ServiceURL))
+            {                
+                throw new ArgumentNullException("Configuration parameter 'serviceURL' can not be null.");
+            }
+            if (communicationProvider != null)
+            {
+                this.communicationProvider = communicationProvider;
+            }
+            else
+            {                                
+                throw new ArgumentNullException("Argument 'communicationProvider' can not be null.");
+            }
+            
 
-      if (s.Code != StatusCodes.OK || string.IsNullOrEmpty(s.SessionInfo))
-      {
-        return loginStatus;
-      }
+            this.settings = settings;
 
-      this.sessionInfo = s.SessionInfo;
+            this.settings.ServiceURL = this.settings.ServiceURL.TrimEnd(new char[] { '/', '?' });
+            if (!this.settings.ServiceURL.EndsWith("/api/xml"))
+            {
+                this.settings.ServiceURL = this.settings.ServiceURL + "/api/xml";
+            }
+        }
 
-      loginStatus.Result = true;
-      return loginStatus;
-    }
+        /// <summary>
+        /// Performs log-in procedure.
+        /// </summary>
+        /// <param name="sInfo">after successful Login, <see cref="LoginStatus"/> contains Session ID to be used for single-sign-on.</param>
+        /// <returns>An <see cref="LoginStatus"/></returns>
+        /// <example>
+        /// url: action=Login&Login=bobs@acme.com&password=football&Session=
+        /// cookie: BREEZESESSION
+        /// </example>
+        public LoginStatus Login()
+        {
+            return this.Login(this.settings.NetUser, this.settings.NetPassword);
+        }
 
-    /// <summary>
-    /// Performs log-out procedure.
-    /// </summary>
-    /// <returns>A <see cref="bool"/> value, indicating whenever the action was successful.</returns>
-    public bool Logout()
-    {
-      ApiStatus s = this.ProcessApiRequest("logout", null);
+        /// <summary>
+        /// Performs log-in procedure.
+        /// </summary>
+        /// <param name="userName">valid Adobe Connect account Name.</param>
+        /// <param name="userPassword">valid Adobe Connect account password.</param>
+        /// <param name="sInfo">after successful Login, <see cref="LoginStatus"/> contains Session ID to be used for single-sign-on.</param>
+        /// <returns>An <see cref="LoginStatus"/></returns>
+        /// <example>
+        /// url: action=Login&Login=bobs@acme.com&password=football&Session=
+        /// cookie: BREEZESESSION
+        /// </example>
+        public LoginStatus Login(string userName, string userPassword)
+        {
+            ApiStatus s = this.ProcessApiRequest("login", string.Format("login={0}&password={1}", userName, userPassword));
 
-      if (s.Code == StatusCodes.OK)
-      {
-        this.sessionInfo = null;
-        return true;
-      }
+            var loginStatus = Helpers.WrapBaseStatusInfo<LoginStatus>(s);
 
-      return false;
-    }
+            if (s.Code != StatusCodes.OK || string.IsNullOrEmpty(s.SessionInfo))
+            {
+                return loginStatus;
+            }
 
-    /// <summary>
-    /// Returns information about currently logged in user.
-    /// </summary>
-    /// <returns>
-    ///   <see cref="UserInfo" />
-    /// </returns>
-    public UserInfoStatus GetUserInfo()
-    {
-      ApiStatus s = this.ProcessApiRequest("common-info", null);
+            this.sessionInfo = s.SessionInfo;
 
-      var userInfoStatus = Helpers.WrapBaseStatusInfo<UserInfoStatus>(s);
+            loginStatus.Result = true;
+            return loginStatus;
+        }
 
-      if (s.Code != StatusCodes.OK || s.ResultDocument == null)
-      {
-        return null;
-      }
+        /// <summary>
+        /// Performs log-out procedure.
+        /// </summary>
+        /// <returns>A <see cref="bool"/> value, indicating whenever the action was successful.</returns>
+        public bool Logout()
+        {
+            ApiStatus s = this.ProcessApiRequest("logout", null);
 
-      try
-      {
-        var userInfo = XmlSerializerHelpersGeneric.FromXML<UserInfo>(s.ResultDocument.Descendants("user").FirstOrDefault().CreateReader());
-        userInfoStatus.Result = userInfo;
-        return userInfoStatus;
-      }
-      catch (Exception ex)
-      {
-        throw ex.InnerException;
-      }
-    }
+            if (s.Code == StatusCodes.OK)
+            {
+                this.sessionInfo = null;
+                return true;
+            }
 
-    /// <summary>
-    /// Creates metadata for a SCO, or updates existing metadata describing a SCO.
-    /// Call sco-update to create metadata only for SCOs that represent Content, including
-    /// meetings. You also need to upload Content files with either sco-upload or Connect Enterprise Manager.
-    /// You must provide a folder-id or a sco-id, but not both. If you pass a folder-id, scoupdate
-    /// creates a new SCO and returns a sco-id. If the SCO already exists and you pass a
-    /// sco-id, sco-update updates the metadata describing the SCO.
-    /// After you create a new SCO with sco-update, call permissions-update to specify which
-    /// users and groups can access it.
-    /// </summary>
-    /// <returns>
-    ///   <see cref="ApiStatus" />
-    /// </returns>
-    internal ApiStatus ScoUpdate(MeetingUpdateItem meetingUpdateItem, out MeetingDetail meetingDetail)
-    {
-      meetingDetail = null;
+            return false;
+        }
 
-      if (meetingUpdateItem == null)
-        return null;
+        /// <summary>
+        /// Returns information about currently logged in user.
+        /// </summary>
+        /// <returns>
+        ///   <see cref="UserInfo" />
+        /// </returns>
+        public UserInfoStatus GetUserInfo()
+        {
+            ApiStatus s = this.ProcessApiRequest("common-info", null);
 
-      string cmdParams = Helpers.StructToQueryString(meetingUpdateItem, true);
+            var userInfoStatus = Helpers.WrapBaseStatusInfo<UserInfoStatus>(s);
 
-      ApiStatus s = this.ProcessApiRequest("sco-update", cmdParams);
+            if (s.Code != StatusCodes.OK || s.ResultDocument == null)
+            {
+                return null;
+            }
 
-      if (s.Code != StatusCodes.OK || s.ResultDocument == null)
-      {
-        return s;
-      }
+            try
+            {
+                var userInfo = XmlSerializerHelpersGeneric.FromXML<UserInfo>(s.ResultDocument.Descendants("user").FirstOrDefault().CreateReader());
+                userInfoStatus.Result = userInfo;
+                return userInfoStatus;
+            }
+            catch 
+            {                
+                throw;
+            }
+        }
 
-      //notice: no '/sco' will be returned during update
-      XElement meetingDetailNode = s.ResultDocument.XPathSelectElement("//sco");
-      if (meetingDetailNode == null)
-        return s;
+        /// <summary>
+        /// Creates metadata for a SCO, or updates existing metadata describing a SCO.
+        /// Call sco-update to create metadata only for SCOs that represent Content, including
+        /// meetings. You also need to upload Content files with either sco-upload or Connect Enterprise Manager.
+        /// You must provide a folder-id or a sco-id, but not both. If you pass a folder-id, scoupdate
+        /// creates a new SCO and returns a sco-id. If the SCO already exists and you pass a
+        /// sco-id, sco-update updates the metadata describing the SCO.
+        /// After you create a new SCO with sco-update, call permissions-update to specify which
+        /// users and groups can access it.
+        /// </summary>
+        /// <returns>
+        ///   <see cref="ApiStatus" />
+        /// </returns>
+        internal ApiStatus ScoUpdate(MeetingUpdateItem meetingUpdateItem, out MeetingDetail meetingDetail)
+        {
+            meetingDetail = null;
 
-      try
-      {
-        meetingDetail = XmlSerializerHelpersGeneric.FromXML<MeetingDetail>(meetingDetailNode.CreateReader());
-        meetingDetail.FullUrl = this.ResolveFullUrl(meetingDetail.UrlPath);
-      }
-      catch (Exception ex)
-      {        
-        s.Code = StatusCodes.Invalid;
-        s.SubCode = StatusSubCodes.Format;
-        s.InnerException = ex;
+            if (meetingUpdateItem == null)
+                return null;
 
-        //rollback: delete the meeting
-        if (!string.IsNullOrEmpty(meetingDetail.ScoId))
-          this.ScoDelete(new[]
-          {
+            string cmdParams = Helpers.StructToQueryString(meetingUpdateItem, true);
+
+            ApiStatus s = this.ProcessApiRequest("sco-update", cmdParams);
+
+            if (s.Code != StatusCodes.OK || s.ResultDocument == null)
+            {
+                return s;
+            }
+
+            //notice: no '/sco' will be returned during update
+            XElement meetingDetailNode = s.ResultDocument.XPathSelectElement("//sco");
+            if (meetingDetailNode == null)
+                return s;
+
+            try
+            {
+                meetingDetail = XmlSerializerHelpersGeneric.FromXML<MeetingDetail>(meetingDetailNode.CreateReader());
+                meetingDetail.FullUrl = this.ResolveFullUrl(meetingDetail.UrlPath);
+            }
+            catch (Exception ex)
+            {
+                s.Code = StatusCodes.Invalid;
+                s.SubCode = StatusSubCodes.Format;
+                s.InnerException = ex;
+
+                //rollback: delete the meeting
+                if (!string.IsNullOrEmpty(meetingDetail.ScoId))
+                    this.ScoDelete(new[]
+                    {
             meetingDetail.ScoId
-          });
+          });                
+                throw;
+            }
 
-        throw ex.InnerException;
-      }
-
-      return s;
-    }
-
-    /// <summary>
-    /// Deletes one or more objects (SCOs).
-    /// If the sco-id you specify is for a Folder, all the contents of the specified Folder are deleted. To
-    /// delete multiple SCOs, specify multiple sco-id parameters.
-    /// You can use a call such as sco-contents to check the ref-count of the SCO, which is the
-    /// number of other SCOs that reference this SCO. If the SCO has no references, you can safely
-    /// Remove it, and the server reclaims the space.
-    /// If the SCO has references, removing it can cause the SCOs that reference it to stop working,
-    /// or the server not to reclaim the space, or both. For example, if a Course references a quiz
-    /// presentation, removing the presentation might make the Course stop working.
-    /// As another example, if a Meeting has used a Content SCO (such as a presentation or video),
-    /// there is a reference from the Meeting to the SCO. Deleting the Content SCO does not free
-    /// disk space, because the Meeting still references it.
-    /// To delete a SCO, you need at least Manage permission (see permission-id for details). Users
-    /// who belong to the built-in authors group have Manage permission on their own Content
-    /// Folder, so they can delete Content within it.
-    /// </summary>
-    /// <param name="scoId">The sco identifier.</param>
-    /// <returns>
-    ///   <see cref="ApiStatus" />
-    /// </returns>
-    public ApiStatus ScoDelete(string[] scoId)
-    {
-      for (int i = 0; i < scoId.Length; i++)
-      {
-        scoId[i] = "sco-id=" + scoId[i];
-      }
-
-      ApiStatus s = this.ProcessApiRequest("sco-delete", string.Join("&", scoId));
-
-      return s;
-    }
-
-    /// <summary>
-    /// Prepares the API request, by combining action, parameters, and session information.
-    /// </summary>
-    /// <param name="apiAction">The API action.</param>
-    /// <param name="apiParams">The API parameters.</param>
-    /// <returns>
-    ///   <see cref="ApiStatus" />
-    /// </returns>
-    public ApiStatus ProcessApiRequest(string apiAction, string apiParams)
-    {
-      if (!string.IsNullOrEmpty(this.sessionInfo) && this.settings.UseSessionParam)
-      {
-        if (String.IsNullOrEmpty(apiParams))
-        {
-          apiParams = "session=" + this.sessionInfo;
-        }
-        else
-        {
-          apiParams = String.Concat("session=", this.sessionInfo, @"&", apiParams);
-        }
-      }
-
-      return this.communicationProvider.ProcessRequest(apiAction, apiParams);
-    }
-
-    #region internal routines
-
-    internal IEnumerable<MeetingItem> PreProcessMeetingItems(IEnumerable<XElement> list, XmlRootAttribute xmlRootAttribute)
-    {
-      IEnumerable<MeetingItem> meetingItems = list.Select(meetingInfo => XmlSerializerHelpersGeneric.FromXML<MeetingItem>(meetingInfo.CreateReader(), xmlRootAttribute));
-
-      foreach (var meetingItem in meetingItems)
-      {
-        //NOTE: if Folder =>  date-begin is null
-        meetingItem.Duration = meetingItem.DateEnd.Subtract(meetingItem.DateBegin);
-
-        if (!string.IsNullOrEmpty(meetingItem.UrlPath))
-        {
-          Uri uri = new Uri(this.settings.ServiceURL);
-          meetingItem.FullUrl = uri.GetComponents(UriComponents.SchemeAndServer, UriFormat.SafeUnescaped) + meetingItem.UrlPath;
+            return s;
         }
 
-        yield return meetingItem;
-      }
+        /// <summary>
+        /// Deletes one or more objects (SCOs).
+        /// If the sco-id you specify is for a Folder, all the contents of the specified Folder are deleted. To
+        /// delete multiple SCOs, specify multiple sco-id parameters.
+        /// You can use a call such as sco-contents to check the ref-count of the SCO, which is the
+        /// number of other SCOs that reference this SCO. If the SCO has no references, you can safely
+        /// Remove it, and the server reclaims the space.
+        /// If the SCO has references, removing it can cause the SCOs that reference it to stop working,
+        /// or the server not to reclaim the space, or both. For example, if a Course references a quiz
+        /// presentation, removing the presentation might make the Course stop working.
+        /// As another example, if a Meeting has used a Content SCO (such as a presentation or video),
+        /// there is a reference from the Meeting to the SCO. Deleting the Content SCO does not free
+        /// disk space, because the Meeting still references it.
+        /// To delete a SCO, you need at least Manage permission (see permission-id for details). Users
+        /// who belong to the built-in authors group have Manage permission on their own Content
+        /// Folder, so they can delete Content within it.
+        /// </summary>
+        /// <param name="scoId">The sco identifier.</param>
+        /// <returns>
+        ///   <see cref="ApiStatus" />
+        /// </returns>
+        public ApiStatus ScoDelete(string[] scoId)
+        {
+            for (int i = 0; i < scoId.Length; i++)
+            {
+                scoId[i] = "sco-id=" + scoId[i];
+            }
+
+            ApiStatus s = this.ProcessApiRequest("sco-delete", string.Join("&", scoId));
+
+            return s;
+        }
+
+        /// <summary>
+        /// Prepares the API request, by combining action, parameters, and session information.
+        /// </summary>
+        /// <param name="apiAction">The API action.</param>
+        /// <param name="apiParams">The API parameters.</param>
+        /// <returns>
+        ///   <see cref="ApiStatus" />
+        /// </returns>
+        public ApiStatus ProcessApiRequest(string apiAction, string apiParams)
+        {
+            if (!string.IsNullOrEmpty(this.sessionInfo) && this.settings.UseSessionParam)
+            {
+                if (String.IsNullOrEmpty(apiParams))
+                {
+                    apiParams = "session=" + this.sessionInfo;
+                }
+                else
+                {
+                    apiParams = String.Concat("session=", this.sessionInfo, @"&", apiParams);
+                }
+            }
+
+            return this.communicationProvider.ProcessRequest(apiAction, apiParams, this.settings);
+        }
+
+        #region internal routines
+
+        internal IEnumerable<MeetingItem> PreProcessMeetingItems(IEnumerable<XElement> list, XmlRootAttribute xmlRootAttribute)
+        {
+            IEnumerable<MeetingItem> meetingItems = list.Select(meetingInfo => XmlSerializerHelpersGeneric.FromXML<MeetingItem>(meetingInfo.CreateReader(), xmlRootAttribute));
+
+            foreach (var meetingItem in meetingItems)
+            {
+                //NOTE: if Folder =>  date-begin is null
+                meetingItem.Duration = meetingItem.DateEnd.Subtract(meetingItem.DateBegin);
+
+                if (!string.IsNullOrEmpty(meetingItem.UrlPath))
+                {
+                    Uri uri = new Uri(this.settings.ServiceURL);
+                    meetingItem.FullUrl = uri.GetComponents(UriComponents.SchemeAndServer, UriFormat.SafeUnescaped) + meetingItem.UrlPath;
+                }
+
+                yield return meetingItem;
+            }
+        }
+
+        internal string ResolveFullUrl(string urlPath)
+        {
+            if (string.IsNullOrEmpty(urlPath))
+            {
+                return string.Empty;
+            }
+
+            var u = new Uri(this.settings.ServiceURL);
+            return u.GetComponents(UriComponents.SchemeAndServer, UriFormat.SafeUnescaped) + urlPath;
+        }
+
+        #endregion
+
     }
-
-    internal string ResolveFullUrl(string urlPath)
-    {
-      if (string.IsNullOrEmpty(urlPath))
-      {
-        return string.Empty;
-      }
-
-      var u = new Uri(this.settings.ServiceURL);
-      return u.GetComponents(UriComponents.SchemeAndServer, UriFormat.SafeUnescaped) + urlPath;
-    }
-
-    #endregion
-
-  }
 }

--- a/Source/AdobeConnectSDK/Common/Helpers.cs
+++ b/Source/AdobeConnectSDK/Common/Helpers.cs
@@ -43,7 +43,7 @@
       if (subStatusNode != null)
       {
         operationApiStatus.SubCode = Helpers.ReflectEnum<StatusSubCodes>(subStatusNode.Attribute("subcode").Value);
-        operationApiStatus.InvalidField = subStatusNode.Attribute("field") == null ? null : subStatusNode.Attribute("field").Value;
+        operationApiStatus.InvalidField = subStatusNode.Attribute("field")?.Value;
       }
 
       var exceptionNode = statusNode.Descendants("exception").FirstOrDefault();
@@ -80,8 +80,6 @@
       {
         throw;
       }
-
-      return null;
     }
 
     public static Enum ReflectEnum(Type PrimaryType, string EnumField)
@@ -94,9 +92,7 @@
       catch
       {
         throw;
-      }
-
-      return null;
+      }      
     }
 
     public static T ReflectEnum<T>(string enumField)
@@ -113,8 +109,6 @@
       {
         throw;
       }
-
-      return default(T);
     }
 
     public static string StructToQueryString(object pSetup, bool XmlElementAttributeOverride)
@@ -157,21 +151,19 @@
         string _filedName = fi.Name.Replace('_', '-').ToLower();
 
         if (XmlElementAttributeOverride)
-        {          
-          XmlElementAttribute[] xmlElementAttributes = fi.GetCustomAttributes(typeof(XmlElementAttribute), false) as XmlElementAttribute[];
-          if (xmlElementAttributes != null && xmlElementAttributes.Length > 0)
-          {
-            if (!string.IsNullOrEmpty(xmlElementAttributes[0].ElementName))
-              _filedName = xmlElementAttributes[0].ElementName;
-          }
+        {
+                    if (fi.GetCustomAttributes(typeof(XmlElementAttribute), false) is XmlElementAttribute[] xmlElementAttributes && xmlElementAttributes.Length > 0)
+                    {
+                        if (!string.IsNullOrEmpty(xmlElementAttributes[0].ElementName))
+                            _filedName = xmlElementAttributes[0].ElementName;
+                    }
 
-          XmlAttributeAttribute[] xmlAttributes = fi.GetCustomAttributes(typeof(XmlAttributeAttribute), false) as XmlAttributeAttribute[];
-          if (xmlAttributes != null && xmlAttributes.Length > 0)
-          {
-            if (!string.IsNullOrEmpty(xmlAttributes[0].AttributeName))
-              _filedName = xmlAttributes[0].AttributeName;
-          }
-        }
+                    if (fi.GetCustomAttributes(typeof(XmlAttributeAttribute), false) is XmlAttributeAttribute[] xmlAttributes && xmlAttributes.Length > 0)
+                    {
+                        if (!string.IsNullOrEmpty(xmlAttributes[0].AttributeName))
+                            _filedName = xmlAttributes[0].AttributeName;
+                    }
+                }
 
         cmdParams.AppendFormat("&{0}={1}", _filedName, HttpUtilsInternal.UrlEncode(_fieldValue.ToString()));
       }

--- a/Source/AdobeConnectSDK/Common/HttpUtilsInternal.cs
+++ b/Source/AdobeConnectSDK/Common/HttpUtilsInternal.cs
@@ -16,8 +16,7 @@ namespace AdobeConnectSDK.Common
         /// <returns></returns>
         public static string HttpGetContents(string url, NetworkCredential accessCredentials, string proxyUrl)
         {
-            HttpWebRequest HttpWReq = WebRequest.Create(url) as HttpWebRequest;
-            if (HttpWReq == null) return null;
+            if (!(WebRequest.Create(url) is HttpWebRequest HttpWReq)) return null;
 
             if (accessCredentials != null)
             {
@@ -65,9 +64,8 @@ namespace AdobeConnectSDK.Common
                 }
             }
             catch (Exception ex)
-            {
-                HttpWReq.Abort();
-                throw ex;
+            {                
+                throw;
             }
             finally
             {
@@ -75,7 +73,6 @@ namespace AdobeConnectSDK.Common
                     HttpWResp.Close();
             }
 
-            return null;
         }
 
         public static string UrlEncode(string str)

--- a/Source/AdobeConnectSDK/Common/XmlSerializerHelpersGeneric.cs
+++ b/Source/AdobeConnectSDK/Common/XmlSerializerHelpersGeneric.cs
@@ -18,10 +18,12 @@ namespace AdobeConnectSDK.Common
     {
       Type underlingType = typeof(T);
 
-      XmlAttributes attrs = new XmlAttributes();
-      attrs.XmlRoot = xmlRootAttribute;
+            XmlAttributes attrs = new XmlAttributes
+            {
+                XmlRoot = xmlRootAttribute
+            };
 
-      var xmlAttributeOverrides = new XmlAttributeOverrides();
+            var xmlAttributeOverrides = new XmlAttributeOverrides();
       xmlAttributeOverrides.Add(underlingType, attrs);
 
       XmlSerializer serializer = GetSerializerInstance(underlingType, xmlAttributeOverrides);
@@ -115,6 +117,7 @@ namespace AdobeConnectSDK.Common
         }
         else
           throw new ArgumentException("Empty list cannot be serialized.", "sourceDataObject");
+
       }
 
       XmlSerializer serializer = GetSerializerInstance(srcType);

--- a/Source/AdobeConnectSDK/Extensions/MeetingManagement.cs
+++ b/Source/AdobeConnectSDK/Extensions/MeetingManagement.cs
@@ -1,374 +1,414 @@
 ﻿namespace AdobeConnectSDK.Extensions
 {
-  using System;
-  using System.Collections.Generic;
-  using System.Linq;
-  using System.Xml.Linq;
-  using System.Xml.Serialization;
-  using System.Xml.XPath;
-  using AdobeConnectSDK.Common;
-  using AdobeConnectSDK.Model;
-
-  /// <summary>
-  /// Meeting extensions.
-  /// </summary>
-  public static class MeetingManagement
-  {
-    /// <summary>
-    /// List all meetings on the server
-    /// </summary>
-    /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
-    /// <returns>
-    ///   <see cref="EnumerableResultStatus{T}" />
-    /// </returns>
-    public static EnumerableResultStatus<MeetingItem> GetAllMeetings(this AdobeConnectXmlAPI adobeConnectXmlApi)
-    {
-      return GetAllMeetings(adobeConnectXmlApi, null);
-    }
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Xml.Linq;
+    using System.Xml.Serialization;
+    using System.Xml.XPath;
+    using AdobeConnectSDK.Common;
+    using AdobeConnectSDK.Model;
 
     /// <summary>
-    /// List all meetings on the server
+    /// Meeting extensions.
     /// </summary>
-    /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
-    /// <param name="likeName">filter like the Name of the Meeting</param>
-    /// <returns>
-    ///   <see cref="EnumerableResultStatus{T}" />
-    /// </returns>
-    public static EnumerableResultStatus<MeetingItem> GetAllMeetings(this AdobeConnectXmlAPI adobeConnectXmlApi, string likeName)
+    public static class MeetingManagement
     {
-      string filterName = String.Empty;
-
-      if (!String.IsNullOrEmpty(likeName))
-        filterName = @"&filter-like-name=" + likeName;
-
-      ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("report-bulk-objects", "filter-type=meeting" + filterName);
-
-      var resultStatus = Helpers.WrapBaseStatusInfo<EnumerableResultStatus<MeetingItem>>(s);
-
-      if (s.Code != StatusCodes.OK || s.ResultDocument == null || s.ResultDocument.Root == null)
-      {
-        return resultStatus;
-      }
-
-      IEnumerable<XElement> list;
-
-      try
-      {
-        IEnumerable<XElement> meetingsData = s.ResultDocument.XPathSelectElements("//report-bulk-objects/row");
-        list = meetingsData as IList<XElement> ?? meetingsData;
-      }
-      catch (Exception ex)
-      {
-        throw ex.InnerException;
-      }
-
-      resultStatus.Result = adobeConnectXmlApi.PreProcessMeetingItems(list, new XmlRootAttribute("row"));
-
-      return resultStatus;
-    }
-
-    /// <summary>
-    /// Returns a list of SCOs within another SCO. The enclosing SCO can be a Folder, Meeting, or
-    /// Curriculum.
-    /// In general, the contained SCOs can be of any type meetings, courses, curriculums, Content,
-    /// events, folders, trees, or links (see the list in Type). However, the Type of the contained SCO
-    /// needs to be valid for the enclosing SCO. For example, courses are contained within
-    /// curriculums, and Meeting Content is contained within meetings.
-    /// Because folders are SCOs, the returned list includes SCOs and subfolders at the next
-    /// hierarchical level, but not the contents of the subfolders. To include the subfolder contents,
-    /// call sco-expanded-contents.
-    /// </summary>
-    /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
-    /// <param name="scoId">Room/Folder ID</param>
-    /// <returns>
-    ///   <see cref="EnumerableResultStatus{T}" />
-    /// </returns>
-    public static EnumerableResultStatus<MeetingItem> GetMeetingsInRoom(this AdobeConnectXmlAPI adobeConnectXmlApi, string scoId)
-    {
-      ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("sco-contents", String.Format("sco-id={0}", scoId));
-
-      var resultStatus = Helpers.WrapBaseStatusInfo<EnumerableResultStatus<MeetingItem>>(s);
-
-      if (s.Code != StatusCodes.OK || s.ResultDocument == null)
-      {
-        return resultStatus;
-      }
-
-      IEnumerable<XElement> list;
-
-      try
-      {
-        IEnumerable<XElement> meetingsData = s.ResultDocument.XPathSelectElements("//sco");
-        list = meetingsData as IList<XElement> ?? meetingsData;
-      }
-      catch (Exception ex)
-      {
-        throw ex.InnerException;
-      }
-
-      resultStatus.Result = adobeConnectXmlApi.PreProcessMeetingItems(list, new XmlRootAttribute("sco"));
-
-      return resultStatus;
-    }
-
-    /// <summary>
-    /// Provides information about a SCO on Connect Enterprise. The object can have any valid
-    /// SCO Type. See Type for a list of the allowed SCO types.
-    /// The response includes the account the SCO belongs to, the dates it was created and last
-    /// modified, the owner, the URL that reaches it, and other data. For some types of SCOs, the
-    /// response also includes information about a template from which this SCO was created.
-    /// </summary>
-    /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
-    /// <param name="scoId">Meeting id</param>
-    /// <returns>
-    ///   <see cref="EnumerableResultStatus{T}" />
-    /// </returns>
-    public static MeetingDetailStatus GetMeetingDetail(this AdobeConnectXmlAPI adobeConnectXmlApi, string scoId)
-    {
-      ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("sco-info", String.Format("sco-id={0}", scoId));
-
-      var resultStatus = Helpers.WrapBaseStatusInfo<MeetingDetailStatus>(s);
-
-      if (s.Code != StatusCodes.OK || s.ResultDocument == null)
-      {
-        return resultStatus;
-      }
-
-      try
-      {
-        XElement nodeData = s.ResultDocument.XPathSelectElement("//sco");
-
-        if (nodeData == null || !nodeData.HasElements)
+        /// <summary>
+        /// List all meetings on the server
+        /// </summary>
+        /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
+        /// <returns>
+        ///   <see cref="EnumerableResultStatus{T}" />
+        /// </returns>
+        public static EnumerableResultStatus<MeetingItem> GetAllMeetings(this AdobeConnectXmlAPI adobeConnectXmlApi)
         {
-          return null;
+            return GetAllMeetings(adobeConnectXmlApi, null);
         }
 
-        resultStatus.Result = XmlSerializerHelpersGeneric.FromXML<MeetingDetail>(nodeData.CreateReader(), new XmlRootAttribute("sco"));
-        resultStatus.Result.FullUrl = adobeConnectXmlApi.ResolveFullUrl(resultStatus.Result.UrlPath);
+        /// <summary>
+        /// List all meetings on the server
+        /// </summary>
+        /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
+        /// <param name="likeName">filter like the Name of the Meeting</param>
+        /// <returns>
+        ///   <see cref="EnumerableResultStatus{T}" />
+        /// </returns>
+        public static EnumerableResultStatus<MeetingItem> GetAllMeetings(this AdobeConnectXmlAPI adobeConnectXmlApi, string likeName)
+        {
+            string filterName = String.Empty;
 
-        return resultStatus;
-      }
-      catch (Exception ex)
-      {
-        throw ex.InnerException;
-      }
+            if (!String.IsNullOrEmpty(likeName))
+                filterName = @"&filter-like-name=" + likeName;
+
+            ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("report-bulk-objects", "filter-type=meeting" + filterName);
+
+            var resultStatus = Helpers.WrapBaseStatusInfo<EnumerableResultStatus<MeetingItem>>(s);
+
+            if (s.Code != StatusCodes.OK || s.ResultDocument == null || s.ResultDocument.Root == null)
+            {
+                return resultStatus;
+            }
+
+            IEnumerable<XElement> list;
+
+            try
+            {
+                IEnumerable<XElement> meetingsData = s.ResultDocument.XPathSelectElements("//report-bulk-objects/row");
+                list = meetingsData as IList<XElement> ?? meetingsData;
+            }
+            catch (Exception ex)
+            {
+                throw;
+            }
+
+            resultStatus.Result = adobeConnectXmlApi.PreProcessMeetingItems(list, new XmlRootAttribute("row"));
+
+            return resultStatus;
+        }
+
+        /// <summary>
+        /// Returns a list of SCOs within another SCO. The enclosing SCO can be a Folder, Meeting, or
+        /// Curriculum.
+        /// In general, the contained SCOs can be of any type meetings, courses, curriculums, Content,
+        /// events, folders, trees, or links (see the list in Type). However, the Type of the contained SCO
+        /// needs to be valid for the enclosing SCO. For example, courses are contained within
+        /// curriculums, and Meeting Content is contained within meetings.
+        /// Because folders are SCOs, the returned list includes SCOs and subfolders at the next
+        /// hierarchical level, but not the contents of the subfolders. To include the subfolder contents,
+        /// call sco-expanded-contents.
+        /// </summary>
+        /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
+        /// <param name="scoId">Room/Folder ID</param>
+        /// <returns>
+        ///   <see cref="EnumerableResultStatus{T}" />
+        /// </returns>
+        public static EnumerableResultStatus<MeetingItem> GetMeetingsInRoom(this AdobeConnectXmlAPI adobeConnectXmlApi, string scoId)
+        {
+            ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("sco-contents", String.Format("sco-id={0}", scoId));
+
+            var resultStatus = Helpers.WrapBaseStatusInfo<EnumerableResultStatus<MeetingItem>>(s);
+
+            if (s.Code != StatusCodes.OK || s.ResultDocument == null)
+            {
+                return resultStatus;
+            }
+
+            IEnumerable<XElement> list;
+
+            try
+            {
+                IEnumerable<XElement> meetingsData = s.ResultDocument.XPathSelectElements("//sco");
+                list = meetingsData as IList<XElement> ?? meetingsData;
+            }
+            catch (Exception ex)
+            {
+                throw;
+            }
+
+            resultStatus.Result = adobeConnectXmlApi.PreProcessMeetingItems(list, new XmlRootAttribute("sco"));
+
+            return resultStatus;
+        }
+
+        /// <summary>
+        /// Provides information about a SCO on Connect Enterprise. The object can have any valid
+        /// SCO Type. See Type for a list of the allowed SCO types.
+        /// The response includes the account the SCO belongs to, the dates it was created and last
+        /// modified, the owner, the URL that reaches it, and other data. For some types of SCOs, the
+        /// response also includes information about a template from which this SCO was created.
+        /// </summary>
+        /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
+        /// <param name="scoId">Meeting id</param>
+        /// <returns>
+        ///   <see cref="EnumerableResultStatus{T}" />
+        /// </returns>
+        public static MeetingDetailStatus GetMeetingDetail(this AdobeConnectXmlAPI adobeConnectXmlApi, string scoId)
+        {
+            ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("sco-info", String.Format("sco-id={0}", scoId));
+
+            var resultStatus = Helpers.WrapBaseStatusInfo<MeetingDetailStatus>(s);
+
+            if (s.Code != StatusCodes.OK || s.ResultDocument == null)
+            {
+                return resultStatus;
+            }
+
+            try
+            {
+                XElement nodeData = s.ResultDocument.XPathSelectElement("//sco");
+
+                if (nodeData == null || !nodeData.HasElements)
+                {
+                    return null;
+                }
+
+                resultStatus.Result = XmlSerializerHelpersGeneric.FromXML<MeetingDetail>(nodeData.CreateReader(), new XmlRootAttribute("sco"));
+                resultStatus.Result.FullUrl = adobeConnectXmlApi.ResolveFullUrl(resultStatus.Result.UrlPath);
+
+                return resultStatus;
+            }
+            catch (Exception ex)
+            {
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Creates a new Meeting.
+        /// </summary>
+        /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
+        /// <param name="meetingUpdateItem"><see cref="MeetingUpdateItem" /></param>
+        /// <param name="meetingDetail"><see cref="MeetingDetail" /></param>
+        /// <returns>
+        ///   <see cref="ApiStatus" />
+        /// </returns>
+        public static ApiStatus MeetingCreate(this AdobeConnectXmlAPI adobeConnectXmlApi, MeetingUpdateItem meetingUpdateItem, out MeetingDetail meetingDetail)
+        {
+            meetingDetail = null;
+            if (meetingUpdateItem == null)
+                return null;
+
+            if (String.IsNullOrEmpty(meetingUpdateItem.FolderId))
+            {
+                return Helpers.WrapStatusException(StatusCodes.Invalid, StatusSubCodes.Format, new ArgumentNullException("MeetingItem", "FolderID must be set to create new item"));
+            }
+
+            if (meetingUpdateItem.MeetingItemType == SCOtype.NotSet)
+            {
+                return Helpers.WrapStatusException(StatusCodes.Invalid, StatusSubCodes.Format, new ArgumentNullException("MeetingItem", "SCOtype must be set"));
+            }
+
+            meetingUpdateItem.ScoId = null;
+
+            return adobeConnectXmlApi.ScoUpdate(meetingUpdateItem, out meetingDetail);
+        }
+
+        /// <summary>
+        /// Updates the Meeting.
+        /// </summary>
+        /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
+        /// <param name="meetingUpdateItem"><see cref="MeetingUpdateItem" /></param>
+        /// <returns>
+        ///   <see cref="ApiStatus" />
+        /// </returns>
+        public static ApiStatus MeetingUpdate(this AdobeConnectXmlAPI adobeConnectXmlApi, MeetingUpdateItem meetingUpdateItem)
+        {
+
+            if (meetingUpdateItem == null)
+                return null;
+
+            if (String.IsNullOrEmpty(meetingUpdateItem.ScoId))
+            {
+                return Helpers.WrapStatusException(StatusCodes.Invalid, StatusSubCodes.Format, new ArgumentNullException("MeetingItem", "ScoId must be set to update existing item"));
+            }
+
+            meetingUpdateItem.FolderId = null;
+
+            return adobeConnectXmlApi.ScoUpdate(meetingUpdateItem, out MeetingDetail meetingDetail);
+        }
+
+        /// <summary>
+        /// Returns a list of SCOs within another SCO. The enclosing SCO can be a Folder, Meeting, or
+        /// Curriculum.
+        /// </summary>
+        /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
+        /// <param name="scoId">Room/Folder ID</param>
+        /// <returns>
+        ///   <see cref="EnumerableResultStatus{T}" />
+        /// </returns>
+        public static EnumerableResultStatus<XElement> GetMeetingsInRoomRaw(this AdobeConnectXmlAPI adobeConnectXmlApi, string scoId)
+        {
+            ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("sco-contents", String.Format("sco-id={0}", scoId));
+
+            var resultStatus = Helpers.WrapBaseStatusInfo<EnumerableResultStatus<XElement>>(s);
+
+            if (s.Code != StatusCodes.OK || s.ResultDocument == null)
+            {
+                return resultStatus;
+            }
+
+            resultStatus.Result = s.ResultDocument.XPathSelectElements("//sco");
+
+            return resultStatus;
+        }
+
+        /// <summary>
+        /// Provides result from calling GetSCOshortcuts(),
+        /// with conditional filtering applied: scoItem.Type.Equals("meetings")
+        /// </summary>
+        /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
+        /// <returns>
+        ///   <see cref="EnumerableResultStatus{T}" />
+        /// </returns>
+        public static EnumerableResultStatus<ScoShortcut> GetMeetingShortcuts(this AdobeConnectXmlAPI adobeConnectXmlApi)
+        {
+            EnumerableResultStatus<ScoShortcut> itemData = GetSCOshortcuts(adobeConnectXmlApi);
+
+            IEnumerable<ScoShortcut> meetingShortcuts = itemData.Result.Where(shortcut => shortcut.Type == "meetings");
+            itemData.Result = meetingShortcuts;
+            return itemData;
+        }
+
+        /// <summary>
+        /// Provides result from calling GetSCOshortcuts(),
+        /// with conditional filtering applied: scoItem.Type.Equals("meetings")
+        /// </summary>
+        /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
+        /// <returns>
+        ///   <see cref="EnumerableResultStatus{T}" />
+        /// </returns>
+        public static EnumerableResultStatus<ScoShortcut> GeSharedtMeetingShortcuts(this AdobeConnectXmlAPI adobeConnectXmlApi)
+        {
+            EnumerableResultStatus<ScoShortcut> itemData = GetSCOshortcuts(adobeConnectXmlApi);
+
+            IEnumerable<ScoShortcut> meetingShortcuts = itemData.Result.Where(shortcut => shortcut.Type == "meetings");
+            itemData.Result = meetingShortcuts;
+            return itemData;
+        }
+        /// <summary>
+        /// Provides information about all Acrobat Connect meetings for which the user is a Host, invited
+        /// participant, or registered guest. The Meeting can be scheduled in the past, present, or future.
+        /// </summary>
+        /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
+        /// <returns>
+        ///   <see cref="EnumerableResultStatus{T}" />
+        /// </returns>
+        public static EnumerableResultStatus<MeetingItem> GetMyMeetings(this AdobeConnectXmlAPI adobeConnectXmlApi)
+        {
+            return GetMyMeetings(adobeConnectXmlApi, null);
+        }
+
+        /// <summary>
+        /// Provides information about all Acrobat Connect meetings for which the user is a Host, invited
+        /// participant, or registered guest. The Meeting can be scheduled in the past, present, or future.
+        /// </summary>
+        /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
+        /// <param name="likeName">filter like the Name of the Meeting</param>
+        /// <returns>
+        ///   <see cref="EnumerableResultStatus{T}" />
+        /// </returns>
+        public static EnumerableResultStatus<MeetingItem> GetMyMeetings(this AdobeConnectXmlAPI adobeConnectXmlApi, string likeName)
+        {
+            string filterName = null;
+
+            if (!String.IsNullOrEmpty(likeName))
+                filterName = @"filter-like-name=" + likeName;
+
+            ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("report-my-meetings", filterName);
+
+            var resultStatus = Helpers.WrapBaseStatusInfo<EnumerableResultStatus<MeetingItem>>(s);
+
+            if (s.Code != StatusCodes.OK || s.ResultDocument == null)
+            {
+                return resultStatus;
+            }
+
+            IEnumerable<XElement> list;
+
+            try
+            {
+                IEnumerable<XElement> meetingsData = s.ResultDocument.XPathSelectElements("//my-meetings/meeting");
+                list = meetingsData as IList<XElement> ?? meetingsData;
+            }
+            catch (Exception ex)
+            {
+                throw;
+            }
+
+            resultStatus.Result = adobeConnectXmlApi.PreProcessMeetingItems(list, new XmlRootAttribute("meeting"));
+
+            return resultStatus;
+        }
+
+        /// <summary>
+        /// Method is intented to retrieve data from AC 'Content' Folder. E.g.: Quizzes
+        /// </summary>
+        /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
+        /// <param name="scoId">The sco identifier.</param>
+        /// <returns>
+        ///   <see cref="ApiStatus" />, containing ResultDocument if status code is OK and result document is not null; otherwise, null.
+        /// </returns>
+        public static ApiStatus GetQuizzesInRoom(this AdobeConnectXmlAPI adobeConnectXmlApi, string scoId)
+        {
+            ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("sco-contents", String.Format("sco-id={0}", scoId));
+
+            if (s.Code != StatusCodes.OK || s.ResultDocument == null)
+            {
+                return null;
+            }
+
+            return s;
+        }
+
+        /// <summary>
+        /// Provides information about the folders relevant to the current user. These include a Folder for
+        /// the user’s current meetings, a Folder for the user’s Content, as well as folders above them in the
+        /// navigation hierarchy.
+        /// To determine the URL of a SCO, concatenate the url-path returned by sco-info, scocontents,
+        /// or sco-expanded-contents with the domain-Name returned by sco-shortcuts.
+        /// For example, you can concatenate these two strings:
+        /// - http://test.server.com (the domain-Name returned by sco-shortcuts)
+        /// - /f2006123456/ (the url-path returned by sco-info, sco-contents, or scoexpanded-contents)
+        /// The result is this URL: http://test.server.com/f2006123456/
+        /// You can also call sco-contents with the sco-id of a Folder returned by sco-shortcuts to
+        /// see the contents of the Folder.
+        /// </summary>
+        /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
+        /// <returns>
+        ///   <see cref="EnumerableResultStatus{T}" />
+        /// </returns>
+        public static EnumerableResultStatus<ScoShortcut> GetSCOshortcuts(this AdobeConnectXmlAPI adobeConnectXmlApi)
+        {
+            ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("sco-shortcuts", null);
+
+            var resultStatus = Helpers.WrapBaseStatusInfo<EnumerableResultStatus<ScoShortcut>>(s);
+
+            if (s.Code != StatusCodes.OK || s.ResultDocument == null)
+            {
+                return resultStatus;
+            }
+
+            IEnumerable<XElement> list;
+
+            try
+            {
+                IEnumerable<XElement> nodeData = s.ResultDocument.XPathSelectElements("//shortcuts/sco");
+                list = nodeData as IList<XElement> ?? nodeData;
+            }
+            catch (Exception ex)
+            {
+                throw;
+            }
+
+            resultStatus.Result = list.Select(itemInfo => XmlSerializerHelpersGeneric.FromXML<ScoShortcut>(itemInfo.CreateReader()));
+
+            return resultStatus;
+        }
+
+        /// <summary>
+        /// Returns the list of all rooms
+        /// </summary>
+        /// <remarks This function facilates the need to return the list of all 
+        /// urls/rooms for admin view
+        /// <returns><see cref="List<List<bool>>"/>List of List of strings {}</returns>
+        public static EnumerableResultStatus<MeetingItem> GetSharedList(AdobeConnectXmlAPI adobeConnectXmlApi)
+        {
+
+            var sharedMeetings = adobeConnectXmlApi.GetMeetingShortcuts().Result.FirstOrDefault<ScoShortcut>();
+
+            var scoId = (sharedMeetings as ScoShortcut).ScoId;
+
+            var expandedContents = adobeConnectXmlApi.ProcessApiRequest("sco-expanded-contents", String.Format("sco-id={0}&filter-type=meeting", scoId));
+
+            var resultStatus = Helpers.WrapBaseStatusInfo<EnumerableResultStatus<MeetingItem>>(expandedContents);
+
+            var folder = expandedContents.ResultDocument.Descendants("sco").Where(p => p.Attribute("folder-id").Value == scoId);
+
+            resultStatus.Result = folder.Select(meeting => XmlSerializerHelpersGeneric.FromXML<MeetingItem>(meeting.CreateReader(), new XmlRootAttribute("sco")));            
+            
+            return resultStatus;
+        }
+
     }
-
-    /// <summary>
-    /// Creates a new Meeting.
-    /// </summary>
-    /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
-    /// <param name="meetingUpdateItem"><see cref="MeetingUpdateItem" /></param>
-    /// <param name="meetingDetail"><see cref="MeetingDetail" /></param>
-    /// <returns>
-    ///   <see cref="ApiStatus" />
-    /// </returns>
-    public static ApiStatus MeetingCreate(this AdobeConnectXmlAPI adobeConnectXmlApi, MeetingUpdateItem meetingUpdateItem, out MeetingDetail meetingDetail)
-    {
-      meetingDetail = null;
-      if (meetingUpdateItem == null)
-        return null;
-
-      if (String.IsNullOrEmpty(meetingUpdateItem.FolderId))
-      {
-        return Helpers.WrapStatusException(StatusCodes.Invalid, StatusSubCodes.Format, new ArgumentNullException("MeetingItem", "FolderID must be set to create new item"));
-      }
-
-      if (meetingUpdateItem.MeetingItemType == SCOtype.NotSet)
-      {
-        return Helpers.WrapStatusException(StatusCodes.Invalid, StatusSubCodes.Format, new ArgumentNullException("MeetingItem", "SCOtype must be set"));
-      }
-
-      meetingUpdateItem.ScoId = null;
-
-      return adobeConnectXmlApi.ScoUpdate(meetingUpdateItem, out meetingDetail);
-    }
-
-    /// <summary>
-    /// Updates the Meeting.
-    /// </summary>
-    /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
-    /// <param name="meetingUpdateItem"><see cref="MeetingUpdateItem" /></param>
-    /// <returns>
-    ///   <see cref="ApiStatus" />
-    /// </returns>
-    public static ApiStatus MeetingUpdate(this AdobeConnectXmlAPI adobeConnectXmlApi, MeetingUpdateItem meetingUpdateItem) 
-    {
-      MeetingDetail meetingDetail = null;
-
-      if (meetingUpdateItem == null)
-        return null;
-
-      if (String.IsNullOrEmpty(meetingUpdateItem.ScoId))
-      {
-        return Helpers.WrapStatusException(StatusCodes.Invalid, StatusSubCodes.Format, new ArgumentNullException("MeetingItem", "ScoId must be set to update existing item"));
-      }
-
-      meetingUpdateItem.FolderId = null;
-
-      return adobeConnectXmlApi.ScoUpdate(meetingUpdateItem, out meetingDetail);
-    }
-
-    /// <summary>
-    /// Returns a list of SCOs within another SCO. The enclosing SCO can be a Folder, Meeting, or
-    /// Curriculum.
-    /// </summary>
-    /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
-    /// <param name="scoId">Room/Folder ID</param>
-    /// <returns>
-    ///   <see cref="EnumerableResultStatus{T}" />
-    /// </returns>
-    public static EnumerableResultStatus<XElement> GetMeetingsInRoomRaw(this AdobeConnectXmlAPI adobeConnectXmlApi, string scoId)
-    {
-      ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("sco-contents", String.Format("sco-id={0}", scoId));
-
-      var resultStatus = Helpers.WrapBaseStatusInfo<EnumerableResultStatus<XElement>>(s);
-
-      if (s.Code != StatusCodes.OK || s.ResultDocument == null)
-      {
-        return resultStatus;
-      }
-
-      resultStatus.Result = s.ResultDocument.XPathSelectElements("//sco");
-
-      return resultStatus;
-    }
-
-    /// <summary>
-    /// Provides result from calling GetSCOshotcuts(),
-    /// with conditional filtering applied: scoItem.Type.Equals("meetings")
-    /// </summary>
-    /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
-    /// <returns>
-    ///   <see cref="EnumerableResultStatus{T}" />
-    /// </returns>
-    public static EnumerableResultStatus<ScoShortcut> GetMeetingShotcuts(this AdobeConnectXmlAPI adobeConnectXmlApi)
-    {
-      EnumerableResultStatus<ScoShortcut> itemData = GetSCOshotcuts(adobeConnectXmlApi);
-
-      IEnumerable<ScoShortcut> meetingShotcuts = itemData.Result.Where(shortcut => shortcut.Type == "meetings");
-      itemData.Result = meetingShotcuts;
-      return itemData;
-    }
-
-    /// <summary>
-    /// Provides information about all Acrobat Connect meetings for which the user is a Host, invited
-    /// participant, or registered guest. The Meeting can be scheduled in the past, present, or future.
-    /// </summary>
-    /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
-    /// <returns>
-    ///   <see cref="EnumerableResultStatus{T}" />
-    /// </returns>
-    public static EnumerableResultStatus<MeetingItem> GetMyMeetings(this AdobeConnectXmlAPI adobeConnectXmlApi)
-    {
-      return GetMyMeetings(adobeConnectXmlApi, null);
-    }
-
-    /// <summary>
-    /// Provides information about all Acrobat Connect meetings for which the user is a Host, invited
-    /// participant, or registered guest. The Meeting can be scheduled in the past, present, or future.
-    /// </summary>
-    /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
-    /// <param name="likeName">filter like the Name of the Meeting</param>
-    /// <returns>
-    ///   <see cref="EnumerableResultStatus{T}" />
-    /// </returns>
-    public static EnumerableResultStatus<MeetingItem> GetMyMeetings(this AdobeConnectXmlAPI adobeConnectXmlApi, string likeName)
-    {
-      string filterName = null;
-
-      if (!String.IsNullOrEmpty(likeName))
-        filterName = @"filter-like-name=" + likeName;
-
-      ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("report-my-meetings", filterName);
-
-      var resultStatus = Helpers.WrapBaseStatusInfo<EnumerableResultStatus<MeetingItem>>(s);
-
-      if (s.Code != StatusCodes.OK || s.ResultDocument == null)
-      {
-        return resultStatus;
-      }
-
-      IEnumerable<XElement> list;
-
-      try
-      {
-        IEnumerable<XElement> meetingsData = s.ResultDocument.XPathSelectElements("//my-meetings/meeting");
-        list = meetingsData as IList<XElement> ?? meetingsData;
-      }
-      catch (Exception ex)
-      {
-        throw ex.InnerException;
-      }
-
-      resultStatus.Result = adobeConnectXmlApi.PreProcessMeetingItems(list, new XmlRootAttribute("meeting"));
-
-      return resultStatus;
-    }
-
-    /// <summary>
-    /// Method is intented to retrieve data from AC 'Content' Folder. E.g.: Quizzes
-    /// </summary>
-    /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
-    /// <param name="scoId">The sco identifier.</param>
-    /// <returns>
-    ///   <see cref="ApiStatus" />, containing ResultDocument if status code is OK and result document is not null; otherwise, null.
-    /// </returns>
-    public static ApiStatus GetQuizzesInRoom(this AdobeConnectXmlAPI adobeConnectXmlApi, string scoId)
-    {
-      ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("sco-contents", String.Format("sco-id={0}", scoId));
-
-      if (s.Code != StatusCodes.OK || s.ResultDocument == null)
-      {
-        return null;
-      }
-
-      return s;
-    }
-
-    /// <summary>
-    /// Provides information about the folders relevant to the current user. These include a Folder for
-    /// the user’s current meetings, a Folder for the user’s Content, as well as folders above them in the
-    /// navigation hierarchy.
-    /// To determine the URL of a SCO, concatenate the url-path returned by sco-info, scocontents,
-    /// or sco-expanded-contents with the domain-Name returned by sco-shortcuts.
-    /// For example, you can concatenate these two strings:
-    /// - http://test.server.com (the domain-Name returned by sco-shortcuts)
-    /// - /f2006123456/ (the url-path returned by sco-info, sco-contents, or scoexpanded-contents)
-    /// The result is this URL: http://test.server.com/f2006123456/
-    /// You can also call sco-contents with the sco-id of a Folder returned by sco-shortcuts to
-    /// see the contents of the Folder.
-    /// </summary>
-    /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
-    /// <returns>
-    ///   <see cref="EnumerableResultStatus{T}" />
-    /// </returns>
-    public static EnumerableResultStatus<ScoShortcut> GetSCOshotcuts(this AdobeConnectXmlAPI adobeConnectXmlApi)
-    {
-      ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("sco-shortcuts", null);
-
-      var resultStatus = Helpers.WrapBaseStatusInfo<EnumerableResultStatus<ScoShortcut>>(s);
-
-      if (s.Code != StatusCodes.OK || s.ResultDocument == null)
-      {
-        return resultStatus;
-      }
-
-      IEnumerable<XElement> list;
-
-      try
-      {
-        IEnumerable<XElement> nodeData = s.ResultDocument.XPathSelectElements("//shortcuts/sco");
-        list = nodeData as IList<XElement> ?? nodeData;
-      }
-      catch (Exception ex)
-      {
-        throw ex.InnerException;
-      }
-
-      resultStatus.Result = list.Select(itemInfo => XmlSerializerHelpersGeneric.FromXML<ScoShortcut>(itemInfo.CreateReader()));
-
-      return resultStatus;
-    }
-  }
 }

--- a/Source/AdobeConnectSDK/Extensions/PrincipalManagement.cs
+++ b/Source/AdobeConnectSDK/Extensions/PrincipalManagement.cs
@@ -1,365 +1,381 @@
 ﻿namespace AdobeConnectSDK.Extensions
 {
-  using System;
-  using System.Collections.Generic;
-  using System.Linq;
-  using System.Xml.Linq;
-  using System.Xml.XPath;
-  using AdobeConnectSDK.Common;
-  using AdobeConnectSDK.Model;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Xml.Linq;
+    using System.Xml.XPath;
+    using AdobeConnectSDK.Common;
+    using AdobeConnectSDK.Model;
 
-  /// <summary>
-  /// Principal management extensions.
-  /// </summary>
-  public static class PrincipalManagement
-  {
     /// <summary>
-    /// Provides information about one principal, either a user or a group.
+    /// Principal management extensions.
     /// </summary>
-    /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
-    /// <param name="principalId">The principal identifier.</param>
-    /// <returns>
-    ///   <see cref="PrincipalInfo" />
-    /// </returns>
-    /// <exception cref="System.ArgumentNullException">principalId</exception>
-    public static PrincipalInfoStatus GetPrincipalInfo(this AdobeConnectXmlAPI adobeConnectXmlApi, string principalId)
+    public static class PrincipalManagement
     {
-      if (String.IsNullOrEmpty(principalId))
-        throw new ArgumentNullException("principalId");
-
-      ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("principal-info", String.Format("principal-id={0}", principalId));
-
-      var principalInfoStatus = Helpers.WrapBaseStatusInfo<PrincipalInfoStatus>(s);
-
-      if (s.Code != StatusCodes.OK || s.ResultDocument == null)
-      {
-        return null;
-      }
-
-      var principalInfo = new PrincipalInfo();
-
-      try
-      {
-        XElement contactData = s.ResultDocument.XPathSelectElement("//contact");
-
-        if (contactData != null)
+        /// <summary>
+        /// Provides information about one principal, either a user or a group.
+        /// </summary>
+        /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
+        /// <param name="principalId">The principal identifier.</param>
+        /// <returns>
+        ///   <see cref="PrincipalInfo" />
+        /// </returns>
+        /// <exception cref="System.ArgumentNullException">principalId</exception>
+        public static PrincipalInfoStatus GetPrincipalInfo(this AdobeConnectXmlAPI adobeConnectXmlApi, string principalId)
         {
-          principalInfo.Contact = XmlSerializerHelpersGeneric.FromXML<Contact>(contactData.CreateReader());
+            if (String.IsNullOrEmpty(principalId))
+                throw new ArgumentNullException("principalId");
+
+            ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("principal-info", String.Format("principal-id={0}", principalId));
+
+            var principalInfoStatus = Helpers.WrapBaseStatusInfo<PrincipalInfoStatus>(s);
+
+            if (s.Code != StatusCodes.OK || s.ResultDocument == null)
+            {
+                return null;
+            }
+
+            var principalInfo = new PrincipalInfo();
+
+            try
+            {
+                XElement contactData = s.ResultDocument.XPathSelectElement("//contact");
+
+                if (contactData != null)
+                {
+                    principalInfo.Contact = XmlSerializerHelpersGeneric.FromXML<Contact>(contactData.CreateReader());
+                }
+
+                XElement preferencesData = s.ResultDocument.XPathSelectElement("//preferences");
+
+                if (preferencesData != null)
+                {
+                    principalInfo.Preferences = XmlSerializerHelpersGeneric.FromXML<Preferences>(preferencesData.CreateReader());
+                }
+
+                XElement principalData = s.ResultDocument.XPathSelectElement("//principal");
+
+                if (principalData != null)
+                {
+                    principalInfo.PrincipalData = XmlSerializerHelpersGeneric.FromXML<Principal>(principalData.CreateReader());
+                }
+
+            }
+            catch (Exception ex)
+            {
+                throw;
+            }
+
+            principalInfoStatus.Result = principalInfo;
+
+            return principalInfoStatus;
         }
 
-        XElement preferencesData = s.ResultDocument.XPathSelectElement("//preferences");
-
-        if (preferencesData != null)
+        /// <summary>
+        /// Creates or updates a user or group. The user or group (that is, the principal) is created or
+        /// updated in the same account as the user making the call.
+        /// </summary>
+        /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
+        /// <param name="principalSetup"><see cref="PrincipalSetup" /></param>
+        /// <param name="principal"><see cref="Principal" /></param>
+        /// <returns>
+        ///   <see cref="ApiStatus" />
+        /// </returns>
+        public static ApiStatus PrincipalUpdate(this AdobeConnectXmlAPI adobeConnectXmlApi, PrincipalSetup principalSetup, out Principal principal)
         {
-          principalInfo.Preferences = XmlSerializerHelpersGeneric.FromXML<Preferences>(preferencesData.CreateReader());
+            string cmdParams = Helpers.StructToQueryString(principalSetup, true);
+
+            principal = null;
+
+            ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("principal-update", cmdParams);
+
+            if (s.Code != StatusCodes.OK || s.ResultDocument == null)
+            {
+                return s;
+            }
+
+            principal = XmlSerializerHelpersGeneric.FromXML<Principal>(s.ResultDocument.XPathSelectElement("//principal").CreateReader());
+
+            return s;
         }
 
-        XElement principalData = s.ResultDocument.XPathSelectElement("//principal");
-
-        if (principalData != null)
+        /// <summary>
+        /// Removes one or more principals, either users or groups.
+        /// To delete principals, you must have Administrator privilege.
+        /// To delete multiple principals, specify multiple principal-id parameters. All of the principals
+        /// you specify will be deleted.
+        /// The principal-id can identify either a user or group. If you specify a user, the user is
+        /// removed from any groups the user belongs to. If you specify a group, the group is deleted, but
+        /// the users who belong to it are not.
+        /// </summary>
+        /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
+        /// <param name="principalId">The principal identifier.</param>
+        /// <returns>
+        ///   <see cref="ApiStatus" />
+        /// </returns>
+        public static ApiStatus PrincipalDelete(this AdobeConnectXmlAPI adobeConnectXmlApi, string[] principalId)
         {
-          principalInfo.PrincipalData = XmlSerializerHelpersGeneric.FromXML<Principal>(principalData.CreateReader());
+            for (int i = 0; i < principalId.Length; i++)
+            {
+                principalId[i] = "principal-id=" + principalId[i];
+            }
+
+            ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("principals-delete", String.Join("&", principalId));
+
+            return s;
         }
 
-      }
-      catch (Exception ex)
-      {        
-        throw ex.InnerException;
-      }
+        /// <summary>
+        /// Changes a user’s password. A password can be changed in either of these cases:
+        /// By an Administrator logged in to the account, with or without the user’s old password
+        /// By any Connect Enterprise user, with the user’s principal-id number, Login Name, and old password
+        /// </summary>
+        /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
+        /// <param name="userId">The user identifier.</param>
+        /// <param name="passwordOld">The old password.</param>
+        /// <param name="password">The new password.</param>
+        /// <returns>
+        ///   <see cref="ApiStatus" />
+        /// </returns>
+        public static ApiStatus PrincipalUpdatePwd(this AdobeConnectXmlAPI adobeConnectXmlApi, string userId, string passwordOld, string password)
+        {
+            ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("user-update-pwd", String.Format("user-id={0}&password-old={1}&password={2}", userId, passwordOld, password));
 
-      principalInfoStatus.Result = principalInfo;
+            return s;
+        }
 
-      return principalInfoStatus;
+        /// <summary>
+        /// Adds one or more principals to a group, or removes one or more principals from a group.
+        /// To update multiple principals and groups, specify multiple trios of group-id, principal-id,
+        /// and is-member parameters.
+        /// </summary>
+        /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
+        /// <param name="groupId">The ID of the group in which you want to add or change members.</param>
+        /// <param name="principalId">The ID of the principal whose membership status you want to update. Returned by principal-info.</param>
+        /// <param name="isMember">Whether the principal is added to (true) or deleted from (false) the group.</param>
+        /// <returns>
+        ///   <see cref="ApiStatus" />
+        /// </returns>
+        public static ApiStatus PrincipalGroupMembershipUpdate(this AdobeConnectXmlAPI adobeConnectXmlApi, string groupId, string principalId, bool isMember)
+        {
+            ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("group-membership-update", String.Format("group-id={0}&principal-id={1}&is-member={2}", groupId, principalId, isMember ? 1 : 0));
+
+            return s;
+        }
+
+        /// <summary>
+        /// Provides a complete list of users and groups, including primary groups.
+        /// </summary>
+        /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
+        /// <param name="groupId">The group identifier.</param>
+        /// <param name="filterBy">Optional filtering parameter.</param>
+        /// <returns>
+        ///   <see cref="EnumerableResultStatus{T}" />
+        /// </returns>
+        public static EnumerableResultStatus<PrincipalListItem> GetPrincipalList(this AdobeConnectXmlAPI adobeConnectXmlApi, string groupId, string filterBy)
+        {
+            ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("principal-list", String.Format("group-id={0}&{1}", groupId, filterBy));
+
+            var resultStatus = Helpers.WrapBaseStatusInfo<EnumerableResultStatus<PrincipalListItem>>(s);
+
+            if (s.Code != StatusCodes.OK || s.ResultDocument == null)
+            {
+                return resultStatus;
+            }
+
+            IEnumerable<XElement> list;
+
+            try
+            {
+                IEnumerable<XElement> nodeData = s.ResultDocument.XPathSelectElements("//principal-list/principal");
+                list = nodeData as IList<XElement> ?? nodeData;
+            }
+            catch (Exception ex)
+            {
+                throw;
+            }
+
+            resultStatus.Result = list.Select(itemInfo => XmlSerializerHelpersGeneric.FromXML<PrincipalListItem>(itemInfo.CreateReader()));
+
+            return resultStatus;
+        }
+
+        /// <summary>
+        /// Provides a complete list of users and groups, including primary groups.
+        /// </summary>
+        /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
+        /// <returns>
+        ///   <see cref="EnumerableResultStatus{T}" />
+        /// </returns>
+        public static EnumerableResultStatus<PrincipalListItem> GetPrincipalList(this AdobeConnectXmlAPI adobeConnectXmlApi)
+        {
+            return adobeConnectXmlApi.GetPrincipalList(String.Empty, String.Empty);
+        }
+
+        /// <summary>
+        /// Returns true if user is Admin
+        /// </summary>
+        /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
+        /// <param name="aclId">acl_id of the current user</param>
+        /// <returns><see cref="bool"/> bool : user us admin ? true : false</returns>
+        public static bool IsAdmin(AdobeConnectXmlAPI adobeConnectXmlApi, string aclId)
+        {
+            ApiStatus apiStatus = adobeConnectXmlApi.ProcessApiRequest("permissions-info", string.Format("acl-id={0}&filter-type=live-admins", aclId));
+
+            var resultStatus = apiStatus.ResultDocument;
+
+            if (apiStatus.Code == StatusCodes.OK || apiStatus.ResultDocument != null) return true;
+            return false;
+        }
+
+        /// <summary>
+        /// Returns the list of principals (users or groups) who have permissions to act on a SCO,
+        /// principal, or account.
+        /// </summary>
+        /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
+        /// <param name="aclId">*Required.
+        /// The ID of a SCO, account, or principal
+        /// that a principal has permission to act
+        /// on. The acl-id is a sco-id, principalid,
+        /// or account-id in other calls.</param>
+        /// <param name="principalId">Optional.
+        /// The ID of a user or group who has a
+        /// permission (even if Denied or not set) to
+        /// act on a SCO, an account, or another principal.</param>
+        /// <param name="filter">Optional filtering parameter.</param>
+        /// <returns>
+        ///   <see cref="EnumerableResultStatus{T}" />
+        /// </returns>
+        public static EnumerableResultStatus<PermissionInfo> GetPermissionsInfo(this AdobeConnectXmlAPI adobeConnectXmlApi, string aclId, string principalId, string filter)
+        {
+            ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("permissions-info", String.Format("acl-id={0}&principal-id={1}&filter-definition={2}", aclId, principalId, filter));
+
+            var resultStatus = Helpers.WrapBaseStatusInfo<EnumerableResultStatus<PermissionInfo>>(s);
+
+            if (s.Code != StatusCodes.OK || s.ResultDocument == null)
+            {
+                return resultStatus;
+            }
+
+            IEnumerable<XElement> list;
+
+            try
+            {
+                IEnumerable<XElement> nodeData = s.ResultDocument.XPathSelectElements("//permissions/principal");
+                list = nodeData as IList<XElement> ?? nodeData;
+            }
+            catch (Exception ex)
+            {
+                throw;
+            }
+
+            resultStatus.Result = list.Select(itemInfo => XmlSerializerHelpersGeneric.FromXML<PermissionInfo>(itemInfo.CreateReader()));
+
+            return resultStatus;
+        }
+
+        /// <summary>
+        /// Resets all permissions any principals have on a SCO to the permissions of its parent SCO. If
+        /// the parent has no permissions set, the child SCO will also have no permissions.
+        /// </summary>
+        /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
+        /// <param name="aclId">*Required.
+        /// The ID of a SCO, account, or principal
+        /// that a principal has permission to act
+        /// on. The acl-id is a sco-id, principalid,
+        /// or account-id in other calls.</param>
+        /// <returns>
+        ///   <see cref="ApiStatus" />
+        /// </returns>
+        public static ApiStatus PermissionsReset(this AdobeConnectXmlAPI adobeConnectXmlApi, string aclId)
+        {
+            ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("permissions-reset", String.Format("acl-id={0}", aclId));
+
+            return s;
+        }
+
+        /// <summary>
+        /// Updates the permissions a principal has to access a SCO, using a trio of principal-id, aclid,
+        /// and permission-id. To update permissions for multiple principals or objects, specify
+        /// multiple trios. You can update more than 200 permissions in a single call to permissionsupdate.
+        /// </summary>
+        /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
+        /// <param name="aclId">*Required.
+        /// The ID of a SCO, account, or principal
+        /// that a principal has permission to act
+        /// on. The acl-id is a sco-id, principalid,
+        /// or account-id in other calls.</param>
+        /// <param name="principalId">*Required.
+        /// The ID of a user or group who has a
+        /// permission (even if Denied or not set) to
+        /// act on a SCO, an account, or another principal.</param>
+        /// <param name="permissionId">*Required. <see cref="PermissionId" />.</param>
+        /// <returns>
+        ///   <see cref="ApiStatus" />
+        /// </returns>
+        public static ApiStatus PermissionsUpdate(this AdobeConnectXmlAPI adobeConnectXmlApi, string aclId, string principalId, PermissionId permissionId)
+        {
+            ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("permissions-update", String.Format("acl-id={0}&principal-id={1}&permission-id={2}", aclId, principalId, Helpers.EnumToString(permissionId)));
+
+            return s;
+        }
+
+        /// <summary>
+        /// The server defines a special principal, public-access, which combines with values of permission-id to create special access permissions to meetings.
+        /// </summary>
+        /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
+        /// <param name="aclId">*Required.
+        /// The ID of a SCO, account, or principal
+        /// that a principal has permission to act
+        /// on. The acl-id is a sco-id, principalid,
+        /// or account-id in other calls.</param>
+        /// <param name="permissionId">*Required. <see cref="SpecialPermissionId" />.</param>
+        /// <returns>
+        ///   <see cref="ApiStatus" />
+        /// </returns>
+        /// <exception cref="System.NotImplementedException"></exception>
+        public static ApiStatus SpecialPermissionsUpdate(this AdobeConnectXmlAPI adobeConnectXmlApi, string aclId, SpecialPermissionId permissionId)
+        {
+            switch (permissionId)
+            {
+                case SpecialPermissionId.Denied:
+                    return PermissionsUpdate(adobeConnectXmlApi, aclId, "public-access", PermissionId.Denied);
+                case SpecialPermissionId.Remove:
+                    return PermissionsUpdate(adobeConnectXmlApi, aclId, "public-access", PermissionId.Remove);
+                case SpecialPermissionId.ViewHidden:
+                    return PermissionsUpdate(adobeConnectXmlApi, aclId, "public-access", PermissionId.ViewHidden);
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
+        /// <summary>
+        /// Subscribes specific participant to specific Course/event
+        /// </summary>
+        /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
+        /// <param name="courseSco">The course sco.</param>
+        /// <param name="principalId">principal/participant id</param>
+        /// <returns>
+        ///   <see cref="ApiStatus" />
+        /// </returns>
+        public static ApiStatus ParticipantSubscribe(this AdobeConnectXmlAPI adobeConnectXmlApi, string courseSco, string principalId)
+        {
+            return PermissionsUpdate(adobeConnectXmlApi, courseSco, principalId, PermissionId.View);
+        }
+
+        /// <summary>
+        /// UnSubscribes specific participant from specific Course/event
+        /// </summary>
+        /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
+        /// <param name="courseSco">The course sco.</param>
+        /// <param name="principalId">principal/participant id</param>
+        /// <returns>
+        ///   <see cref="ApiStatus" />
+        /// </returns>
+        public static ApiStatus ParticipantUnsubscribe(this AdobeConnectXmlAPI adobeConnectXmlApi, string courseSco, string principalId)
+        {
+            return PermissionsUpdate(adobeConnectXmlApi, courseSco, principalId, PermissionId.Remove);
+        }
     }
-
-    /// <summary>
-    /// Creates or updates a user or group. The user or group (that is, the principal) is created or
-    /// updated in the same account as the user making the call.
-    /// </summary>
-    /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
-    /// <param name="principalSetup"><see cref="PrincipalSetup" /></param>
-    /// <param name="principal"><see cref="Principal" /></param>
-    /// <returns>
-    ///   <see cref="ApiStatus" />
-    /// </returns>
-    public static ApiStatus PrincipalUpdate(this AdobeConnectXmlAPI adobeConnectXmlApi, PrincipalSetup principalSetup, out Principal principal)
-    {
-      string cmdParams = Helpers.StructToQueryString(principalSetup, true);
-
-      principal = null;
-
-      ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("principal-update", cmdParams);
-
-      if (s.Code != StatusCodes.OK || s.ResultDocument == null)
-      {
-        return s;
-      }
-
-      principal = XmlSerializerHelpersGeneric.FromXML<Principal>(s.ResultDocument.XPathSelectElement("//principal").CreateReader());
-
-      return s;
-    }
-
-    /// <summary>
-    /// Removes one or more principals, either users or groups.
-    /// To delete principals, you must have Administrator privilege.
-    /// To delete multiple principals, specify multiple principal-id parameters. All of the principals
-    /// you specify will be deleted.
-    /// The principal-id can identify either a user or group. If you specify a user, the user is
-    /// removed from any groups the user belongs to. If you specify a group, the group is deleted, but
-    /// the users who belong to it are not.
-    /// </summary>
-    /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
-    /// <param name="principalId">The principal identifier.</param>
-    /// <returns>
-    ///   <see cref="ApiStatus" />
-    /// </returns>
-    public static ApiStatus PrincipalDelete(this AdobeConnectXmlAPI adobeConnectXmlApi, string[] principalId)
-    {
-      for (int i = 0; i < principalId.Length; i++)
-      {
-        principalId[i] = "principal-id=" + principalId[i];
-      }
-
-      ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("principals-delete", String.Join("&", principalId));
-
-      return s;
-    }
-
-    /// <summary>
-    /// Changes a user’s password. A password can be changed in either of these cases:
-    /// By an Administrator logged in to the account, with or without the user’s old password
-    /// By any Connect Enterprise user, with the user’s principal-id number, Login Name, and old password
-    /// </summary>
-    /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
-    /// <param name="userId">The user identifier.</param>
-    /// <param name="passwordOld">The old password.</param>
-    /// <param name="password">The new password.</param>
-    /// <returns>
-    ///   <see cref="ApiStatus" />
-    /// </returns>
-    public static ApiStatus PrincipalUpdatePwd(this AdobeConnectXmlAPI adobeConnectXmlApi, string userId, string passwordOld, string password)
-    {
-      ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("user-update-pwd", String.Format("user-id={0}&password-old={1}&password={2}", userId, passwordOld, password));
-
-      return s;
-    }
-
-    /// <summary>
-    /// Adds one or more principals to a group, or removes one or more principals from a group.
-    /// To update multiple principals and groups, specify multiple trios of group-id, principal-id,
-    /// and is-member parameters.
-    /// </summary>
-    /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
-    /// <param name="groupId">The ID of the group in which you want to add or change members.</param>
-    /// <param name="principalId">The ID of the principal whose membership status you want to update. Returned by principal-info.</param>
-    /// <param name="isMember">Whether the principal is added to (true) or deleted from (false) the group.</param>
-    /// <returns>
-    ///   <see cref="ApiStatus" />
-    /// </returns>
-    public static ApiStatus PrincipalGroupMembershipUpdate(this AdobeConnectXmlAPI adobeConnectXmlApi, string groupId, string principalId, bool isMember)
-    {
-      ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("group-membership-update", String.Format("group-id={0}&principal-id={1}&is-member={2}", groupId, principalId, isMember ? 1 : 0));
-
-      return s;
-    }
-
-    /// <summary>
-    /// Provides a complete list of users and groups, including primary groups.
-    /// </summary>
-    /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
-    /// <param name="groupId">The group identifier.</param>
-    /// <param name="filterBy">Optional filtering parameter.</param>
-    /// <returns>
-    ///   <see cref="EnumerableResultStatus{T}" />
-    /// </returns>
-    public static EnumerableResultStatus<PrincipalListItem> GetPrincipalList(this AdobeConnectXmlAPI adobeConnectXmlApi, string groupId, string filterBy)
-    {
-      ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("principal-list", String.Format("group-id={0}&{1}", groupId, filterBy));
-
-      var resultStatus = Helpers.WrapBaseStatusInfo<EnumerableResultStatus<PrincipalListItem>>(s);
-
-      if (s.Code != StatusCodes.OK || s.ResultDocument == null)
-      {
-        return resultStatus;
-      }
-
-      IEnumerable<XElement> list;
-
-      try
-      {
-        IEnumerable<XElement> nodeData = s.ResultDocument.XPathSelectElements("//principal-list/principal");
-        list = nodeData as IList<XElement> ?? nodeData;
-      }
-      catch (Exception ex)
-      {
-        throw ex.InnerException;
-      }
-
-      resultStatus.Result = list.Select(itemInfo => XmlSerializerHelpersGeneric.FromXML<PrincipalListItem>(itemInfo.CreateReader()));
-
-      return resultStatus;
-    }
-
-    /// <summary>
-    /// Provides a complete list of users and groups, including primary groups.
-    /// </summary>
-    /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
-    /// <returns>
-    ///   <see cref="EnumerableResultStatus{T}" />
-    /// </returns>
-    public static EnumerableResultStatus<PrincipalListItem> GetPrincipalList(this AdobeConnectXmlAPI adobeConnectXmlApi)
-    {
-      return adobeConnectXmlApi.GetPrincipalList(String.Empty, String.Empty);
-    }
-
-    /// <summary>
-    /// Returns the list of principals (users or groups) who have permissions to act on a SCO,
-    /// principal, or account.
-    /// </summary>
-    /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
-    /// <param name="aclId">*Required.
-    /// The ID of a SCO, account, or principal
-    /// that a principal has permission to act
-    /// on. The acl-id is a sco-id, principalid,
-    /// or account-id in other calls.</param>
-    /// <param name="principalId">Optional.
-    /// The ID of a user or group who has a
-    /// permission (even if Denied or not set) to
-    /// act on a SCO, an account, or another principal.</param>
-    /// <param name="filter">Optional filtering parameter.</param>
-    /// <returns>
-    ///   <see cref="EnumerableResultStatus{T}" />
-    /// </returns>
-    public static EnumerableResultStatus<PermissionInfo> GetPermissionsInfo(this AdobeConnectXmlAPI adobeConnectXmlApi, string aclId, string principalId, string filter)
-    {
-      ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("permissions-info", String.Format("acl-id={0}&principal-id={1}&filter-definition={2}", aclId, principalId, filter));
-
-      var resultStatus = Helpers.WrapBaseStatusInfo<EnumerableResultStatus<PermissionInfo>>(s);
-
-      if (s.Code != StatusCodes.OK || s.ResultDocument == null)
-      {
-        return resultStatus;
-      }
-
-      IEnumerable<XElement> list;
-
-      try
-      {
-        IEnumerable<XElement> nodeData = s.ResultDocument.XPathSelectElements("//permissions/principal");
-        list = nodeData as IList<XElement> ?? nodeData;
-      }
-      catch (Exception ex)
-      {        
-        throw ex.InnerException;
-      }
-
-      resultStatus.Result = list.Select(itemInfo => XmlSerializerHelpersGeneric.FromXML<PermissionInfo>(itemInfo.CreateReader()));
-
-      return resultStatus;
-    }
-
-    /// <summary>
-    /// Resets all permissions any principals have on a SCO to the permissions of its parent SCO. If
-    /// the parent has no permissions set, the child SCO will also have no permissions.
-    /// </summary>
-    /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
-    /// <param name="aclId">*Required.
-    /// The ID of a SCO, account, or principal
-    /// that a principal has permission to act
-    /// on. The acl-id is a sco-id, principalid,
-    /// or account-id in other calls.</param>
-    /// <returns>
-    ///   <see cref="ApiStatus" />
-    /// </returns>
-    public static ApiStatus PermissionsReset(this AdobeConnectXmlAPI adobeConnectXmlApi, string aclId)
-    {
-      ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("permissions-reset", String.Format("acl-id={0}", aclId));
-
-      return s;
-    }
-
-    /// <summary>
-    /// Updates the permissions a principal has to access a SCO, using a trio of principal-id, aclid,
-    /// and permission-id. To update permissions for multiple principals or objects, specify
-    /// multiple trios. You can update more than 200 permissions in a single call to permissionsupdate.
-    /// </summary>
-    /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
-    /// <param name="aclId">*Required.
-    /// The ID of a SCO, account, or principal
-    /// that a principal has permission to act
-    /// on. The acl-id is a sco-id, principalid,
-    /// or account-id in other calls.</param>
-    /// <param name="principalId">*Required.
-    /// The ID of a user or group who has a
-    /// permission (even if Denied or not set) to
-    /// act on a SCO, an account, or another principal.</param>
-    /// <param name="permissionId">*Required. <see cref="PermissionId" />.</param>
-    /// <returns>
-    ///   <see cref="ApiStatus" />
-    /// </returns>
-    public static ApiStatus PermissionsUpdate(this AdobeConnectXmlAPI adobeConnectXmlApi, string aclId, string principalId, PermissionId permissionId)
-    {
-      ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("permissions-update", String.Format("acl-id={0}&principal-id={1}&permission-id={2}", aclId, principalId, Helpers.EnumToString(permissionId)));
-
-      return s;
-    }
-
-    /// <summary>
-    /// The server defines a special principal, public-access, which combines with values of permission-id to create special access permissions to meetings.
-    /// </summary>
-    /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
-    /// <param name="aclId">*Required.
-    /// The ID of a SCO, account, or principal
-    /// that a principal has permission to act
-    /// on. The acl-id is a sco-id, principalid,
-    /// or account-id in other calls.</param>
-    /// <param name="permissionId">*Required. <see cref="SpecialPermissionId" />.</param>
-    /// <returns>
-    ///   <see cref="ApiStatus" />
-    /// </returns>
-    /// <exception cref="System.NotImplementedException"></exception>
-    public static ApiStatus SpecialPermissionsUpdate(this AdobeConnectXmlAPI adobeConnectXmlApi, string aclId, SpecialPermissionId permissionId)
-    {
-      switch (permissionId)
-      {
-        case SpecialPermissionId.Denied:
-          return PermissionsUpdate(adobeConnectXmlApi, aclId, "public-access", PermissionId.Denied);
-        case SpecialPermissionId.Remove:
-          return PermissionsUpdate(adobeConnectXmlApi, aclId, "public-access", PermissionId.Remove);
-        case SpecialPermissionId.ViewHidden:
-          return PermissionsUpdate(adobeConnectXmlApi, aclId, "public-access", PermissionId.ViewHidden);
-        default:
-          throw new NotImplementedException();
-      }
-    }
-
-    /// <summary>
-    /// Subscribes specific participant to specific Course/event
-    /// </summary>
-    /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
-    /// <param name="courseSco">The course sco.</param>
-    /// <param name="principalId">principal/participant id</param>
-    /// <returns>
-    ///   <see cref="ApiStatus" />
-    /// </returns>
-    public static ApiStatus ParticipantSubscribe(this AdobeConnectXmlAPI adobeConnectXmlApi, string courseSco, string principalId)
-    {
-      return PermissionsUpdate(adobeConnectXmlApi, courseSco, principalId, PermissionId.View);
-    }
-
-    /// <summary>
-    /// UnSubscribes specific participant from specific Course/event
-    /// </summary>
-    /// <param name="adobeConnectXmlApi">The adobe connect XML API.</param>
-    /// <param name="courseSco">The course sco.</param>
-    /// <param name="principalId">principal/participant id</param>
-    /// <returns>
-    ///   <see cref="ApiStatus" />
-    /// </returns>
-    public static ApiStatus ParticipantUnsubscribe(this AdobeConnectXmlAPI adobeConnectXmlApi, string courseSco, string principalId)
-    {
-      return PermissionsUpdate(adobeConnectXmlApi, courseSco, principalId, PermissionId.Remove);
-    }
-  }
 }

--- a/Source/AdobeConnectSDK/Extensions/Reporting.cs
+++ b/Source/AdobeConnectSDK/Extensions/Reporting.cs
@@ -46,7 +46,7 @@
       }
       catch (Exception ex)
       {
-        throw ex.InnerException;
+        throw;
       }
 
       resultStatus.Result = list.Select(itemInfo => XmlSerializerHelpersGeneric.FromXML<EventInfo>(itemInfo.CreateReader(), new XmlRootAttribute("event")));
@@ -79,7 +79,7 @@
       }
       catch (Exception ex)
       {        
-        throw ex.InnerException;
+        throw;
       }
     }
 
@@ -139,7 +139,7 @@
       }
       catch (Exception ex)
       {
-        throw ex.InnerException;
+        throw;
       }
 
       resultStatus.Result = list.Select(itemInfo => XmlSerializerHelpersGeneric.FromXML<TransactionInfo>(itemInfo.CreateReader(), new XmlRootAttribute("row")));
@@ -328,7 +328,7 @@
     ///   <see cref="EnumerableResultStatus{T}" />
     /// </returns>
     public static EnumerableResultStatus<XElement> Report_MeetingAttendance(this AdobeConnectXmlAPI adobeConnectXmlApi, string scoId, string filterBy)
-    {
+    {            
       ApiStatus s = adobeConnectXmlApi.ProcessApiRequest("report-meeting-attendance", String.Format("sco-id={0}&{1}", scoId, filterBy));
 
       var resultStatus = Helpers.WrapBaseStatusInfo<EnumerableResultStatus<XElement>>(s);

--- a/Source/AdobeConnectSDK/Interfaces/ICommunicationProvider.cs
+++ b/Source/AdobeConnectSDK/Interfaces/ICommunicationProvider.cs
@@ -15,6 +15,6 @@ namespace AdobeConnectSDK.Interfaces
   /// </summary>
   public interface ICommunicationProvider
   {
-    ApiStatus ProcessRequest(string pAction, string qParams);
+    ApiStatus ProcessRequest(string pAction, string qParams, ISdkSettings settings);
   }
 }

--- a/Source/AdobeConnectSDK/Properties/AssemblyInfo.cs
+++ b/Source/AdobeConnectSDK/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("DmitryStroganov.dk")]
 [assembly: AssemblyProduct("AdobeConnect SDK")]
-[assembly: AssemblyCopyright("Dmitry Stroganov, 2007-2014")]
+[assembly: AssemblyCopyright("Dmitry Stroganov, 2007-2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Source/AdobeConnectSDK/app.config
+++ b/Source/AdobeConnectSDK/app.config
@@ -6,11 +6,14 @@
     <add key="NetUser" value="acUser"/>
     <add key="NetPassword" value="acPassword"/>
     <!--optional parameters below-->
-    <add key="UseSessionParameter" value="true"/>    
+    <add key="UseSessionParameter" value="true"/>
     <add key="NetDomain" value=""/>
     <add key="NetProxyURL" value=""/>
   </appSettings>
   <system.net>
     <defaultProxy useDefaultCredentials="true"></defaultProxy>
   </system.net>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+  </startup>
 </configuration>

--- a/Source/AdobeConnectSDK/packages.config
+++ b/Source/AdobeConnectSDK/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="log4net" version="2.0.8" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
-Changed the constructor for the interface ICommunicationProvider - it now accepts an ISdkSeetings;
-Explicitly throwing the exceptions inside catch blocks to make debug easier - Reporting.cs, PrincipalManagement.cs, MeetingManagement.cs and HttpUtilsInternal;
-Added the method IsAdmin - checks if a specific acl_id is an admin;
-Added the method GetSharedMeetingShortcuts;
-Added the virtual method SetHttpConfiguration, allowing developers having full access to the HttpwebRequest object before it gets send to Adobe Connection. You can override this method to further configure the proxy, cookies, etc;
-Created an overload of the AdobeConnectXmlAPI constructor;